### PR TITLE
Updated to match official, supported mbed-cloud-client

### DIFF
--- a/provisioning/ansible/playbooks/roles/private/mbed-dev/defaults/main.yml
+++ b/provisioning/ansible/playbooks/roles/private/mbed-dev/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 mbed_source_dir: "~/Source/"
 mbed_repo_name: "mbed-cloud-client-example-internal"
-mbed_repo_url: "https://github.com/mray19027/{{ mbed_repo_name }}"
+mbed_repo_url: "https://github.com/armmbed/{{ mbed_repo_name }}"
 mbed_cli: "/usr/local/bin/mbed"

--- a/provisioning/ansible/playbooks/roles/private/mbed-dev/tasks/main.yml
+++ b/provisioning/ansible/playbooks/roles/private/mbed-dev/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: mbed Dev | Clone quickstart client to build our mbed-os application
   git:
-    version: 'move_resources_to_main'
+    version: 'master'
     accept_hostkey: yes
     force: yes
     repo: "{{ mbed_repo_url }}"
@@ -40,10 +40,10 @@
     mode: 0664
 
 - name: mbed Dev | Install the mbed manifest tool with PIP
-  shell: pip install git+https://github.com/mray19027/manifest-tool-restricted.git
+  shell: pip install git+https://github.com/armmbed/manifest-tool-internal.git
 
 - name: mbed Dev | Initialize the manifest tool
-  shell: /home/{{ ansible_env.USER }}/.local/bin/manifest-tool init -d "mbed-quickstart-company" -m "FRDM-K64F" -q --force
+  shell: /home/{{ ansible_env.USER }}/.local/bin/manifest-tool init -d "mbed.quickstart.company" -m "FRDM-K64F" -q --force
 
 - name: mbed Dev | Dump manifest data to /vagrant/{{ current_build_time_epoch.stdout }}.FRDM-K64F.LED.qs_manifest_data.json
   shell: jq '. | {"json":.}' .manifest_tool.json | jq ".\"pem\"=\"$(cat .update-certificates/default.key.pem)\"" | jq ".\"der\"=\"$(base64 -w0 .update-certificates/default.der)\"" | sponge "/vagrant/{{ current_build_time_epoch.stdout }}.FRDM-K64F.LED.qs_manifest_data.json"
@@ -53,15 +53,10 @@
 
 - name: mbed Dev | Change LED blink color to RED in binary
   lineinfile:
-    path: "{{ mbed_source_dir }}{{ mbed_repo_name }}/main.cpp"
+    path: "{{ mbed_source_dir }}{{ mbed_repo_name }}/platform/mbed-os/setup.cpp"
     regexp: 'DigitalOut[ ]*led\((LED_RED|LED_GREEN|LED_BLUE)\);'
     line: 'DigitalOut led(LED_RED);'
     state: present
-
-- name: mbed Dev | Add mbed_app_start offset to mbed_app.json
-  shell: jq '.target_overrides.K64F."target.mbed_app_start" = "0x20400"' mbed_app.json | sponge mbed_app.json
-  args:
-    chdir: "{{ mbed_source_dir }}{{ mbed_repo_name }}"
 
 - name: mbed Dev | Disable mbed-trace.enable in mbed_app.json
   shell: jq '.target_overrides."*"."mbed-trace.enable" = 0' mbed_app.json | sponge mbed_app.json
@@ -83,7 +78,7 @@
 
 - name: mbed Dev | Change LED blink color to GREEN in binary
   lineinfile:
-    path: "{{ mbed_source_dir }}{{ mbed_repo_name }}/main.cpp"
+    path: "{{ mbed_source_dir }}{{ mbed_repo_name }}/platform/mbed-os/setup.cpp"
     regexp: 'DigitalOut[ ]*led\((LED_RED|LED_GREEN|LED_BLUE)\);'
     line: 'DigitalOut led(LED_GREEN);'
     state: present
@@ -98,7 +93,7 @@
 
 - name: mbed Dev | Change LED blink color to BLUE in binary
   lineinfile:
-    path: "{{ mbed_source_dir }}{{ mbed_repo_name }}/main.cpp"
+    path: "{{ mbed_source_dir }}{{ mbed_repo_name }}/platform/mbed-os/setup.cpp"
     regexp: 'DigitalOut[ ]*led\((LED_RED|LED_GREEN|LED_BLUE)\);'
     line: 'DigitalOut led(LED_BLUE);'
     state: present


### PR DESCRIPTION
* mbed-cloud-client-example-internal now has supported resources in master
* Updated manifest-tool to point at armmbed instead of mray19027
* Location of LED defines changed from main.cpp to platform/mbed-os/setup.cpp
* target.mbed_app_start now is default in the application, doesnt need to be added